### PR TITLE
Fix memory leak.

### DIFF
--- a/source/citrus/app.cpp
+++ b/source/citrus/app.cpp
@@ -296,7 +296,7 @@ void ctr::app::install(ctr::fs::MediaType mediaType, FILE* fd, u64 size, std::fu
         }
     }
 
-    delete buf;
+    delete[] buf;
 
     if(ctr::err::has()) {
         AM_CancelCIAInstall(&ciaHandle);


### PR DESCRIPTION
Free memory created by new[] with delete[], otherwise will memory leak.
It have same problem in gpu.cpp, gput.cpp.